### PR TITLE
feat(models): add models

### DIFF
--- a/backend/src/database/entities/base.entity.ts
+++ b/backend/src/database/entities/base.entity.ts
@@ -1,0 +1,23 @@
+import {
+  Column,
+  CreateDateColumn,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm'
+
+export abstract class BaseEntity {
+  @PrimaryGeneratedColumn()
+  id!: number
+
+  @CreateDateColumn()
+  createdAt!: Date
+
+  @UpdateDateColumn()
+  updatedAt!: Date
+
+  @Column({
+    type: 'json',
+    nullable: true,
+  })
+  metadata?: Record<string, string>
+}

--- a/backend/src/database/entities/base.entity.ts
+++ b/backend/src/database/entities/base.entity.ts
@@ -20,7 +20,7 @@ export abstract class BaseEntity {
   deletedAt?: Date
 
   @Column({
-    type: 'json',
+    type: 'jsonb',
     nullable: true,
   })
   metadata?: Record<string, string>

--- a/backend/src/database/entities/base.entity.ts
+++ b/backend/src/database/entities/base.entity.ts
@@ -1,6 +1,7 @@
 import {
   Column,
   CreateDateColumn,
+  DeleteDateColumn,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm'
@@ -14,6 +15,9 @@ export abstract class BaseEntity {
 
   @UpdateDateColumn()
   updatedAt!: Date
+
+  @DeleteDateColumn()
+  deletedAt?: Date
 
   @Column({
     type: 'json',

--- a/backend/src/database/entities/editor.entity.ts
+++ b/backend/src/database/entities/editor.entity.ts
@@ -1,0 +1,15 @@
+import { Entity, JoinColumn, OneToOne } from 'typeorm'
+import { User } from '.'
+import { BaseEntity } from './base.entity'
+import { Template } from './template.entity'
+
+@Entity({ name: 'editors' })
+export class Editor extends BaseEntity {
+  @OneToOne(() => Template, { nullable: false })
+  @JoinColumn({ name: 'template' })
+  template!: Template
+
+  @OneToOne(() => User, { nullable: false })
+  @JoinColumn({ name: 'user' })
+  user!: User
+}

--- a/backend/src/database/entities/editor.entity.ts
+++ b/backend/src/database/entities/editor.entity.ts
@@ -1,7 +1,5 @@
 import { Entity, JoinColumn, OneToOne } from 'typeorm'
-import { User } from '.'
-import { BaseEntity } from './base.entity'
-import { Template } from './template.entity'
+import { BaseEntity, Template, User } from '.'
 
 @Entity({ name: 'editors' })
 export class Editor extends BaseEntity {

--- a/backend/src/database/entities/index.ts
+++ b/backend/src/database/entities/index.ts
@@ -1,1 +1,7 @@
+export * from './base.entity'
 export * from './user.entity'
+export * from './template.entity'
+export * from './editor.entity'
+export * from './issuer.entity'
+export * from './templateVersion.entity'
+export * from './memo.entity'

--- a/backend/src/database/entities/issuer.entity.ts
+++ b/backend/src/database/entities/issuer.entity.ts
@@ -1,0 +1,15 @@
+import { Entity, JoinColumn, OneToOne } from 'typeorm'
+import { User } from '.'
+import { BaseEntity } from './base.entity'
+import { Template } from './template.entity'
+
+@Entity({ name: 'issuers' })
+export class Issuer extends BaseEntity {
+  @OneToOne(() => Template, { nullable: false })
+  @JoinColumn({ name: 'template' })
+  template!: Template
+
+  @OneToOne(() => User, { nullable: false })
+  @JoinColumn({ name: 'user' })
+  user!: User
+}

--- a/backend/src/database/entities/issuer.entity.ts
+++ b/backend/src/database/entities/issuer.entity.ts
@@ -1,7 +1,5 @@
 import { Entity, JoinColumn, OneToOne } from 'typeorm'
-import { User } from '.'
-import { BaseEntity } from './base.entity'
-import { Template } from './template.entity'
+import { BaseEntity, Template, User } from '.'
 
 @Entity({ name: 'issuers' })
 export class Issuer extends BaseEntity {

--- a/backend/src/database/entities/memo.entity.ts
+++ b/backend/src/database/entities/memo.entity.ts
@@ -1,0 +1,45 @@
+import { Column, Entity, Index, JoinColumn, OneToOne } from 'typeorm'
+import { User } from '.'
+import { BaseEntity } from './base.entity'
+import { TemplateVersion } from './templateVersion.entity'
+
+// TODO: Abstract constants
+enum UinType {
+  'NRIC' = 'NRIC',
+}
+
+@Entity({ name: 'memos' })
+export class Memo extends BaseEntity {
+  @OneToOne(() => TemplateVersion, { nullable: false })
+  @JoinColumn({ name: 'template_version' })
+  templateVersion!: TemplateVersion
+
+  @OneToOne(() => User, { nullable: false })
+  @JoinColumn({ name: 'issuer' })
+  issuer!: User
+
+  @Column()
+  uin!: string
+
+  @Column()
+  uinType!: UinType
+
+  @Column()
+  @Index({ unique: true }) // optimize for queries
+  slug!: string
+
+  @Column({ type: 'json' })
+  params!: Record<string, string>
+
+  @Column({ nullable: true })
+  expiresAt?: Date
+
+  @Column({ default: false })
+  isViewed!: boolean
+
+  @Column({ default: false })
+  isVoid!: boolean
+
+  @Column({ nullable: true })
+  voidReason?: string
+}

--- a/backend/src/database/entities/memo.entity.ts
+++ b/backend/src/database/entities/memo.entity.ts
@@ -1,7 +1,5 @@
 import { Column, Entity, Index, JoinColumn, OneToOne } from 'typeorm'
-import { User } from '.'
-import { BaseEntity } from './base.entity'
-import { TemplateVersion } from './templateVersion.entity'
+import { BaseEntity, TemplateVersion, User } from '.'
 
 // TODO: Abstract constants
 enum UinType {

--- a/backend/src/database/entities/memo.entity.ts
+++ b/backend/src/database/entities/memo.entity.ts
@@ -26,7 +26,7 @@ export class Memo extends BaseEntity {
   @Index({ unique: true }) // optimize for queries
   slug!: string
 
-  @Column({ type: 'json' })
+  @Column({ type: 'jsonb' })
   params!: Record<string, string>
 
   @Column({ nullable: true })

--- a/backend/src/database/entities/template.entity.ts
+++ b/backend/src/database/entities/template.entity.ts
@@ -1,4 +1,5 @@
 import { Column, Entity, JoinColumn, OneToOne } from 'typeorm'
+import { TemplateStatus } from '../../types'
 import { BaseEntity, User } from '.'
 
 @Entity({ name: 'templates' })
@@ -10,6 +11,6 @@ export class Template extends BaseEntity {
   @JoinColumn({ name: 'author' })
   author!: User
 
-  @Column({ default: false })
-  isArchived!: boolean
+  @Column()
+  status!: TemplateStatus
 }

--- a/backend/src/database/entities/template.entity.ts
+++ b/backend/src/database/entities/template.entity.ts
@@ -1,0 +1,16 @@
+import { Column, Entity, JoinColumn, OneToOne } from 'typeorm'
+import { User } from '.'
+import { BaseEntity } from './base.entity'
+
+@Entity({ name: 'templates' })
+export class Template extends BaseEntity {
+  @Column()
+  name!: string
+
+  @OneToOne(() => User, { nullable: false })
+  @JoinColumn({ name: 'author' })
+  author!: User
+
+  @Column({ default: false })
+  isArchived!: boolean
+}

--- a/backend/src/database/entities/template.entity.ts
+++ b/backend/src/database/entities/template.entity.ts
@@ -1,6 +1,5 @@
 import { Column, Entity, JoinColumn, OneToOne } from 'typeorm'
-import { User } from '.'
-import { BaseEntity } from './base.entity'
+import { BaseEntity, User } from '.'
 
 @Entity({ name: 'templates' })
 export class Template extends BaseEntity {

--- a/backend/src/database/entities/templateVersion.entity.ts
+++ b/backend/src/database/entities/templateVersion.entity.ts
@@ -22,4 +22,7 @@ export class TemplateVersion extends BaseEntity {
   // Defaults to true because a new version should, by definition, be the latest
   @Column({ default: true })
   isLatestVersion!: boolean
+
+  @Column()
+  version!: number
 }

--- a/backend/src/database/entities/templateVersion.entity.ts
+++ b/backend/src/database/entities/templateVersion.entity.ts
@@ -1,0 +1,27 @@
+import { Column, Entity, JoinColumn, OneToOne } from 'typeorm'
+import { User } from '.'
+import { BaseEntity } from './base.entity'
+import { Template } from './template.entity'
+
+@Entity({ name: 'template_versions' })
+export class TemplateVersion extends BaseEntity {
+  @OneToOne(() => Template, { nullable: false })
+  @JoinColumn({ name: 'template' })
+  template!: Template
+
+  @OneToOne(() => User, { nullable: false })
+  @JoinColumn({ name: 'editor' })
+  editor!: User
+
+  @Column()
+  body!: string
+
+  @Column({
+    type: 'json',
+  })
+  paramsRequired!: Record<string, string>
+
+  // Defaults to true because a new version should, by definition, be the latest
+  @Column({ default: true })
+  isLatestVersion!: boolean
+}

--- a/backend/src/database/entities/templateVersion.entity.ts
+++ b/backend/src/database/entities/templateVersion.entity.ts
@@ -15,7 +15,7 @@ export class TemplateVersion extends BaseEntity {
   body!: string
 
   @Column({
-    type: 'json',
+    type: 'jsonb',
   })
   paramsRequired!: Record<string, string>
 

--- a/backend/src/database/entities/templateVersion.entity.ts
+++ b/backend/src/database/entities/templateVersion.entity.ts
@@ -1,4 +1,5 @@
 import { Column, Entity, JoinColumn, OneToOne } from 'typeorm'
+import { TemplateBlock } from '../../types'
 import { BaseEntity, Template, User } from '.'
 
 @Entity({ name: 'template_versions' })
@@ -11,8 +12,8 @@ export class TemplateVersion extends BaseEntity {
   @JoinColumn({ name: 'editor' })
   editor!: User
 
-  @Column()
-  body!: string
+  @Column({ type: 'jsonb' })
+  body!: TemplateBlock[]
 
   @Column({
     type: 'jsonb',

--- a/backend/src/database/entities/templateVersion.entity.ts
+++ b/backend/src/database/entities/templateVersion.entity.ts
@@ -1,7 +1,5 @@
 import { Column, Entity, JoinColumn, OneToOne } from 'typeorm'
-import { User } from '.'
-import { BaseEntity } from './base.entity'
-import { Template } from './template.entity'
+import { BaseEntity, Template, User } from '.'
 
 @Entity({ name: 'template_versions' })
 export class TemplateVersion extends BaseEntity {

--- a/backend/src/database/entities/user.entity.ts
+++ b/backend/src/database/entities/user.entity.ts
@@ -1,10 +1,8 @@
-import { Entity, Column, PrimaryGeneratedColumn } from 'typeorm'
+import { Entity, Column } from 'typeorm'
+import { BaseEntity } from './base.entity'
 
-@Entity()
-export class User {
-  @PrimaryGeneratedColumn()
-  id!: number
-
+@Entity({ name: 'users' })
+export class User extends BaseEntity {
   @Column({
     unique: true,
   })
@@ -13,8 +11,11 @@ export class User {
   @Column({
     nullable: true,
   })
-  apiKeyHash!: string
+  apiKeyHash?: string
 
-  // @Column({ default: {} })
-  // scopes?: Record<string, string>
+  @Column({
+    type: 'json',
+    nullable: true,
+  })
+  apiKeyScopes?: string[]
 }

--- a/backend/src/database/entities/user.entity.ts
+++ b/backend/src/database/entities/user.entity.ts
@@ -14,7 +14,7 @@ export class User extends BaseEntity {
   apiKeyHash?: string
 
   @Column({
-    type: 'json',
+    type: 'jsonb',
     nullable: true,
   })
   apiKeyScopes?: string[]

--- a/backend/src/database/entities/user.entity.ts
+++ b/backend/src/database/entities/user.entity.ts
@@ -1,5 +1,5 @@
 import { Entity, Column } from 'typeorm'
-import { BaseEntity } from './base.entity'
+import { BaseEntity } from './'
 
 @Entity({ name: 'users' })
 export class User extends BaseEntity {

--- a/backend/src/database/migrations/1642057540594-CreateUsers.ts
+++ b/backend/src/database/migrations/1642057540594-CreateUsers.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class CreateUsers1642057540594 implements MigrationInterface {
+  name = 'CreateUsers1642057540594'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "users" ("id" SERIAL NOT NULL, "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP NOT NULL DEFAULT now(), "metadata" json, "email" character varying NOT NULL, "api_key_hash" character varying, "api_key_scopes" json, CONSTRAINT "UQ_97672ac88f789774dd47f7c8be3" UNIQUE ("email"), CONSTRAINT "PK_a3ffb1c0c8416b9fc6f907b7433" PRIMARY KEY ("id"))`,
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "users"`)
+  }
+}

--- a/backend/src/database/migrations/1642059833739-CreateTemplates.ts
+++ b/backend/src/database/migrations/1642059833739-CreateTemplates.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class CreateTemplates1642059833739 implements MigrationInterface {
+  name = 'CreateTemplates1642059833739'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "templates" ("id" SERIAL NOT NULL, "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP NOT NULL DEFAULT now(), "metadata" json, "name" character varying NOT NULL, "is_archived" boolean NOT NULL DEFAULT false, "author" integer NOT NULL, CONSTRAINT "REL_dded581013fa728069e9ddbd6e" UNIQUE ("author"), CONSTRAINT "PK_515948649ce0bbbe391de702ae5" PRIMARY KEY ("id"))`,
+    )
+    await queryRunner.query(
+      `ALTER TABLE "templates" ADD CONSTRAINT "FK_dded581013fa728069e9ddbd6e5" FOREIGN KEY ("author") REFERENCES "users"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "templates" DROP CONSTRAINT "FK_dded581013fa728069e9ddbd6e5"`,
+    )
+    await queryRunner.query(`DROP TABLE "templates"`)
+  }
+}

--- a/backend/src/database/migrations/1642060191069-CreateEditors.ts
+++ b/backend/src/database/migrations/1642060191069-CreateEditors.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class CreateEditors1642060191069 implements MigrationInterface {
+  name = 'CreateEditors1642060191069'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "editors" ("id" SERIAL NOT NULL, "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP NOT NULL DEFAULT now(), "metadata" json, "template" integer NOT NULL, "user" integer NOT NULL, CONSTRAINT "REL_1b8ea56a50e51c81d6fa74f9e3" UNIQUE ("template"), CONSTRAINT "REL_e1df85ceb0796e03b6a3202ce8" UNIQUE ("user"), CONSTRAINT "PK_98bd9cd67ad6c3e6d95a83a8a27" PRIMARY KEY ("id"))`,
+    )
+    await queryRunner.query(
+      `ALTER TABLE "editors" ADD CONSTRAINT "FK_1b8ea56a50e51c81d6fa74f9e37" FOREIGN KEY ("template") REFERENCES "templates"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    )
+    await queryRunner.query(
+      `ALTER TABLE "editors" ADD CONSTRAINT "FK_e1df85ceb0796e03b6a3202ce86" FOREIGN KEY ("user") REFERENCES "users"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "editors" DROP CONSTRAINT "FK_e1df85ceb0796e03b6a3202ce86"`,
+    )
+    await queryRunner.query(
+      `ALTER TABLE "editors" DROP CONSTRAINT "FK_1b8ea56a50e51c81d6fa74f9e37"`,
+    )
+    await queryRunner.query(`DROP TABLE "editors"`)
+  }
+}

--- a/backend/src/database/migrations/1642060590554-CreateIssuers.ts
+++ b/backend/src/database/migrations/1642060590554-CreateIssuers.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class CreateIssuers1642060590554 implements MigrationInterface {
+  name = 'CreateIssuers1642060590554'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "issuers" ("id" SERIAL NOT NULL, "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP NOT NULL DEFAULT now(), "metadata" json, "template" integer NOT NULL, "user" integer NOT NULL, CONSTRAINT "REL_00062ed3b46ba7c7a86e991e4d" UNIQUE ("template"), CONSTRAINT "REL_fc6d730a04921adfe0a4b7669b" UNIQUE ("user"), CONSTRAINT "PK_36d87e2e6d1edfcbdc561deeaf9" PRIMARY KEY ("id"))`,
+    )
+    await queryRunner.query(
+      `ALTER TABLE "issuers" ADD CONSTRAINT "FK_00062ed3b46ba7c7a86e991e4d8" FOREIGN KEY ("template") REFERENCES "templates"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    )
+    await queryRunner.query(
+      `ALTER TABLE "issuers" ADD CONSTRAINT "FK_fc6d730a04921adfe0a4b7669b9" FOREIGN KEY ("user") REFERENCES "users"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "issuers" DROP CONSTRAINT "FK_fc6d730a04921adfe0a4b7669b9"`,
+    )
+    await queryRunner.query(
+      `ALTER TABLE "issuers" DROP CONSTRAINT "FK_00062ed3b46ba7c7a86e991e4d8"`,
+    )
+    await queryRunner.query(`DROP TABLE "issuers"`)
+  }
+}

--- a/backend/src/database/migrations/1642061421917-CreateTemplateVersions.ts
+++ b/backend/src/database/migrations/1642061421917-CreateTemplateVersions.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class CreateTemplateVersions1642061421917 implements MigrationInterface {
+  name = 'CreateTemplateVersions1642061421917'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "template_versions" ("id" SERIAL NOT NULL, "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP NOT NULL DEFAULT now(), "metadata" json, "body" character varying NOT NULL, "params_required" json NOT NULL, "is_latest_version" boolean NOT NULL DEFAULT true, "template" integer NOT NULL, "editor" integer NOT NULL, CONSTRAINT "REL_22c0c429da953ad79271057e36" UNIQUE ("template"), CONSTRAINT "REL_d3f0d2ee808c09471098b308d6" UNIQUE ("editor"), CONSTRAINT "PK_cfc439255ca2725f4102c554d41" PRIMARY KEY ("id"))`,
+    )
+    await queryRunner.query(
+      `ALTER TABLE "template_versions" ADD CONSTRAINT "FK_22c0c429da953ad79271057e365" FOREIGN KEY ("template") REFERENCES "templates"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    )
+    await queryRunner.query(
+      `ALTER TABLE "template_versions" ADD CONSTRAINT "FK_d3f0d2ee808c09471098b308d67" FOREIGN KEY ("editor") REFERENCES "users"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "template_versions" DROP CONSTRAINT "FK_d3f0d2ee808c09471098b308d67"`,
+    )
+    await queryRunner.query(
+      `ALTER TABLE "template_versions" DROP CONSTRAINT "FK_22c0c429da953ad79271057e365"`,
+    )
+    await queryRunner.query(`DROP TABLE "template_versions"`)
+  }
+}

--- a/backend/src/database/migrations/1642063221294-CreateMemos.ts
+++ b/backend/src/database/migrations/1642063221294-CreateMemos.ts
@@ -1,0 +1,33 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class CreateMemos1642063221294 implements MigrationInterface {
+  name = 'CreateMemos1642063221294'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "memos" ("id" SERIAL NOT NULL, "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP NOT NULL DEFAULT now(), "metadata" json, "uin" character varying NOT NULL, "uin_type" character varying NOT NULL, "slug" character varying NOT NULL, "params" json NOT NULL, "expires_at" TIMESTAMP, "is_viewed" boolean NOT NULL DEFAULT false, "is_void" boolean NOT NULL DEFAULT false, "void_reason" character varying, "template_version" integer NOT NULL, "issuer" integer NOT NULL, CONSTRAINT "REL_ee34c5866c93c11f7095bdbd70" UNIQUE ("template_version"), CONSTRAINT "REL_cb5c213b2f814ba737ac9b50f1" UNIQUE ("issuer"), CONSTRAINT "PK_5f005ade603ff6ea114dcacde0b" PRIMARY KEY ("id"))`,
+    )
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_3b95f052140cf95f2d68d6b046" ON "memos" ("slug") `,
+    )
+    await queryRunner.query(
+      `ALTER TABLE "memos" ADD CONSTRAINT "FK_ee34c5866c93c11f7095bdbd702" FOREIGN KEY ("template_version") REFERENCES "template_versions"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    )
+    await queryRunner.query(
+      `ALTER TABLE "memos" ADD CONSTRAINT "FK_cb5c213b2f814ba737ac9b50f1f" FOREIGN KEY ("issuer") REFERENCES "users"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "memos" DROP CONSTRAINT "FK_cb5c213b2f814ba737ac9b50f1f"`,
+    )
+    await queryRunner.query(
+      `ALTER TABLE "memos" DROP CONSTRAINT "FK_ee34c5866c93c11f7095bdbd702"`,
+    )
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_3b95f052140cf95f2d68d6b046"`,
+    )
+    await queryRunner.query(`DROP TABLE "memos"`)
+  }
+}

--- a/backend/src/database/migrations/1642141480937-AddSoftDeletes.ts
+++ b/backend/src/database/migrations/1642141480937-AddSoftDeletes.ts
@@ -1,0 +1,29 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddSoftDeletes1642141480937 implements MigrationInterface {
+  name = 'AddSoftDeletes1642141480937'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "users" ADD "deleted_at" TIMESTAMP`)
+    await queryRunner.query(
+      `ALTER TABLE "templates" ADD "deleted_at" TIMESTAMP`,
+    )
+    await queryRunner.query(`ALTER TABLE "issuers" ADD "deleted_at" TIMESTAMP`)
+    await queryRunner.query(
+      `ALTER TABLE "template_versions" ADD "deleted_at" TIMESTAMP`,
+    )
+    await queryRunner.query(`ALTER TABLE "memos" ADD "deleted_at" TIMESTAMP`)
+    await queryRunner.query(`ALTER TABLE "editors" ADD "deleted_at" TIMESTAMP`)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "editors" DROP COLUMN "deleted_at"`)
+    await queryRunner.query(`ALTER TABLE "memos" DROP COLUMN "deleted_at"`)
+    await queryRunner.query(
+      `ALTER TABLE "template_versions" DROP COLUMN "deleted_at"`,
+    )
+    await queryRunner.query(`ALTER TABLE "issuers" DROP COLUMN "deleted_at"`)
+    await queryRunner.query(`ALTER TABLE "templates" DROP COLUMN "deleted_at"`)
+    await queryRunner.query(`ALTER TABLE "users" DROP COLUMN "deleted_at"`)
+  }
+}

--- a/backend/src/database/migrations/1642142716829-AddTemplateStatus.ts
+++ b/backend/src/database/migrations/1642142716829-AddTemplateStatus.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddTemplateStatus1642142716829 implements MigrationInterface {
+  name = 'AddTemplateStatus1642142716829'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "templates" RENAME COLUMN "is_archived" TO "status"`,
+    )
+    await queryRunner.query(`ALTER TABLE "templates" DROP COLUMN "status"`)
+    await queryRunner.query(
+      `ALTER TABLE "templates" ADD "status" character varying NOT NULL`,
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "templates" DROP COLUMN "status"`)
+    await queryRunner.query(
+      `ALTER TABLE "templates" ADD "status" boolean NOT NULL DEFAULT false`,
+    )
+    await queryRunner.query(
+      `ALTER TABLE "templates" RENAME COLUMN "status" TO "is_archived"`,
+    )
+  }
+}

--- a/backend/src/database/migrations/1642143771390-UseJsonb.ts
+++ b/backend/src/database/migrations/1642143771390-UseJsonb.ts
@@ -1,0 +1,63 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class UseJsonb1642143771390 implements MigrationInterface {
+  name = 'UseJsonb1642143771390'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "users" DROP COLUMN "metadata"`)
+    await queryRunner.query(`ALTER TABLE "users" ADD "metadata" jsonb`)
+    await queryRunner.query(`ALTER TABLE "users" DROP COLUMN "api_key_scopes"`)
+    await queryRunner.query(`ALTER TABLE "users" ADD "api_key_scopes" jsonb`)
+    await queryRunner.query(`ALTER TABLE "templates" DROP COLUMN "metadata"`)
+    await queryRunner.query(`ALTER TABLE "templates" ADD "metadata" jsonb`)
+    await queryRunner.query(`ALTER TABLE "issuers" DROP COLUMN "metadata"`)
+    await queryRunner.query(`ALTER TABLE "issuers" ADD "metadata" jsonb`)
+    await queryRunner.query(
+      `ALTER TABLE "template_versions" DROP COLUMN "metadata"`,
+    )
+    await queryRunner.query(
+      `ALTER TABLE "template_versions" ADD "metadata" jsonb`,
+    )
+    await queryRunner.query(
+      `ALTER TABLE "template_versions" DROP COLUMN "params_required"`,
+    )
+    await queryRunner.query(
+      `ALTER TABLE "template_versions" ADD "params_required" jsonb NOT NULL`,
+    )
+    await queryRunner.query(`ALTER TABLE "memos" DROP COLUMN "metadata"`)
+    await queryRunner.query(`ALTER TABLE "memos" ADD "metadata" jsonb`)
+    await queryRunner.query(`ALTER TABLE "memos" DROP COLUMN "params"`)
+    await queryRunner.query(`ALTER TABLE "memos" ADD "params" jsonb NOT NULL`)
+    await queryRunner.query(`ALTER TABLE "editors" DROP COLUMN "metadata"`)
+    await queryRunner.query(`ALTER TABLE "editors" ADD "metadata" jsonb`)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "editors" DROP COLUMN "metadata"`)
+    await queryRunner.query(`ALTER TABLE "editors" ADD "metadata" json`)
+    await queryRunner.query(`ALTER TABLE "memos" DROP COLUMN "params"`)
+    await queryRunner.query(`ALTER TABLE "memos" ADD "params" json NOT NULL`)
+    await queryRunner.query(`ALTER TABLE "memos" DROP COLUMN "metadata"`)
+    await queryRunner.query(`ALTER TABLE "memos" ADD "metadata" json`)
+    await queryRunner.query(
+      `ALTER TABLE "template_versions" DROP COLUMN "params_required"`,
+    )
+    await queryRunner.query(
+      `ALTER TABLE "template_versions" ADD "params_required" json NOT NULL`,
+    )
+    await queryRunner.query(
+      `ALTER TABLE "template_versions" DROP COLUMN "metadata"`,
+    )
+    await queryRunner.query(
+      `ALTER TABLE "template_versions" ADD "metadata" json`,
+    )
+    await queryRunner.query(`ALTER TABLE "issuers" DROP COLUMN "metadata"`)
+    await queryRunner.query(`ALTER TABLE "issuers" ADD "metadata" json`)
+    await queryRunner.query(`ALTER TABLE "templates" DROP COLUMN "metadata"`)
+    await queryRunner.query(`ALTER TABLE "templates" ADD "metadata" json`)
+    await queryRunner.query(`ALTER TABLE "users" DROP COLUMN "api_key_scopes"`)
+    await queryRunner.query(`ALTER TABLE "users" ADD "api_key_scopes" json`)
+    await queryRunner.query(`ALTER TABLE "users" DROP COLUMN "metadata"`)
+    await queryRunner.query(`ALTER TABLE "users" ADD "metadata" json`)
+  }
+}

--- a/backend/src/database/migrations/1642155636867-AddTemplateVersionNumber.ts
+++ b/backend/src/database/migrations/1642155636867-AddTemplateVersionNumber.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddTemplateVersionNumber1642155636867
+  implements MigrationInterface
+{
+  name = 'AddTemplateVersionNumber1642155636867'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "template_versions" ADD "version" integer NOT NULL`,
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "template_versions" DROP COLUMN "version"`,
+    )
+  }
+}

--- a/backend/src/database/migrations/1642158187300-UseJsonTemplateBody.ts
+++ b/backend/src/database/migrations/1642158187300-UseJsonTemplateBody.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class UseJsonTemplateBody1642158187300 implements MigrationInterface {
+  name = 'UseJsonTemplateBody1642158187300'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "template_versions" DROP COLUMN "body"`,
+    )
+    await queryRunner.query(
+      `ALTER TABLE "template_versions" ADD "body" jsonb NOT NULL`,
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "template_versions" DROP COLUMN "body"`,
+    )
+    await queryRunner.query(
+      `ALTER TABLE "template_versions" ADD "body" character varying NOT NULL`,
+    )
+  }
+}

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -1,0 +1,1 @@
+export * from './template'

--- a/backend/src/types/template.ts
+++ b/backend/src/types/template.ts
@@ -3,3 +3,20 @@ export enum TemplateStatus {
   Public = 'PUBLIC',
   Archived = 'ARCHIVED',
 }
+
+export enum TemplateBlockType {
+  Header = 'HEADER',
+  Text = 'TEXT',
+}
+
+export interface TemplateHeaderBlock {
+  type: TemplateBlockType.Header
+  data: string
+}
+
+export interface TemplateTextBlock {
+  type: TemplateBlockType.Text
+  data: string
+}
+
+export type TemplateBlock = TemplateHeaderBlock | TemplateTextBlock

--- a/backend/src/types/template.ts
+++ b/backend/src/types/template.ts
@@ -1,0 +1,5 @@
+export enum TemplateStatus {
+  Private = 'PRIVATE',
+  Public = 'PUBLIC',
+  Archived = 'ARCHIVED',
+}


### PR DESCRIPTION
## Context

We need a set of models to start working on the backend routes. 

Closes #23 

## Approach

Add TypeORM entities and migrations to spin up the database according to [this schema](https://excalidraw.com/#json=-Jpozd0QAxjbXqw1_SspU,Gc6dw3_bAZ8mI9aaDnb3vw).

Since the tables are fairly normalized, it might be useful to add utility functions to make common queries less tedious - we can add these as we build out the backend routes. 

## Tests

1. Ensure that you have a clean `memos_dev` database, instructions are in the repo readme
2. Execute `npm run migration:run` and check that the tables created match the schema linked above
