### PR TITLE
fix(auth): create and save new user

### DIFF
--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -47,10 +47,12 @@ export class AuthService {
             where: { email: email },
           })
           if (!foundUser) {
-            foundUser = manager.create(User, user)
+            const newUser = manager.create(User, {
+              email,
+            })
+            foundUser = await manager.save(newUser)
           }
-          const result: User = await manager.save(foundUser)
-          return result
+          return foundUser
         },
       )
       return user


### PR DESCRIPTION
## Context

Trying to login with OTP throws: 

```
ReferenceError: Cannot access 'user' before initialization
```

## Approach

Fix reference error by creating and saving new users trying to login. 

## Tests

Generate and run the migration for `users`, then attempt to login.

ps: lint failing because we're out of github credits 🥲 