### PR TITLE
fix: use common manager for transactions

### DIFF
--- a/backend/src/templates/templates.controller.spec.ts
+++ b/backend/src/templates/templates.controller.spec.ts
@@ -2,12 +2,11 @@ import { Test, TestingModule } from '@nestjs/testing'
 import { TemplatesController } from './templates.controller'
 import { TemplatesService } from './templates.service'
 import { PermissionsService } from './permissions.service'
-import { getRepositoryToken } from '@nestjs/typeorm'
-import { Editor, Issuer, Template, TemplateVersion } from 'database/entities'
+import { getConnectionToken } from '@nestjs/typeorm'
 
 describe('TemplatesController', () => {
   let controller: TemplatesController
-  const mockRepository = {}
+  const mockConnection = {}
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -16,20 +15,8 @@ describe('TemplatesController', () => {
         TemplatesService,
         PermissionsService,
         {
-          provide: getRepositoryToken(Template),
-          useValue: mockRepository,
-        },
-        {
-          provide: getRepositoryToken(TemplateVersion),
-          useValue: mockRepository,
-        },
-        {
-          provide: getRepositoryToken(Editor),
-          useValue: mockRepository,
-        },
-        {
-          provide: getRepositoryToken(Issuer),
-          useValue: mockRepository,
+          provide: getConnectionToken(),
+          useValue: mockConnection,
         },
       ],
     }).compile()

--- a/backend/src/templates/templates.service.spec.ts
+++ b/backend/src/templates/templates.service.spec.ts
@@ -1,12 +1,11 @@
 import { Test, TestingModule } from '@nestjs/testing'
-import { getRepositoryToken } from '@nestjs/typeorm'
-import { Template, TemplateVersion, Editor, Issuer } from 'database/entities'
+import { getConnectionToken } from '@nestjs/typeorm'
 import { PermissionsService } from './permissions.service'
 import { TemplatesService } from './templates.service'
 
 describe('TemplatesService', () => {
   let service: TemplatesService
-  const mockRepository = {}
+  const mockConnection = {}
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -14,20 +13,8 @@ describe('TemplatesService', () => {
         TemplatesService,
         PermissionsService,
         {
-          provide: getRepositoryToken(Template),
-          useValue: mockRepository,
-        },
-        {
-          provide: getRepositoryToken(TemplateVersion),
-          useValue: mockRepository,
-        },
-        {
-          provide: getRepositoryToken(Editor),
-          useValue: mockRepository,
-        },
-        {
-          provide: getRepositoryToken(Issuer),
-          useValue: mockRepository,
+          provide: getConnectionToken(),
+          useValue: mockConnection,
         },
       ],
     }).compile()

--- a/backend/src/templates/templates.service.ts
+++ b/backend/src/templates/templates.service.ts
@@ -32,7 +32,7 @@ export class TemplatesService {
   ): Promise<CreateTemplateResponseDto> {
     const { name, body } = _data
 
-    return await this.connection.transaction(async (manager) => {
+    return this.connection.transaction(async (manager) => {
       const templateRepository = manager.getRepository(Template)
       const templateVersionRepository = manager.getRepository(TemplateVersion)
       const editorRepository = manager.getRepository(Editor)

--- a/backend/src/templates/templates.util.ts
+++ b/backend/src/templates/templates.util.ts
@@ -1,5 +1,5 @@
 import { Editor, Issuer, User } from 'database/entities'
-import { Repository } from 'typeorm'
+import { EntityManager } from 'typeorm'
 import mustache from 'mustache'
 
 /**
@@ -7,10 +7,10 @@ import mustache from 'mustache'
  */
 export const isTemplateEditor = async (
   user: User,
-  editorRepo: Repository<Editor>,
+  manager: EntityManager,
   templateId: number,
 ) => {
-  const editor = await editorRepo.findOne({
+  const editor = await manager.findOne(Editor, {
     where: {
       user,
       template: {
@@ -26,10 +26,10 @@ export const isTemplateEditor = async (
  */
 export const isTemplateIssuer = async (
   user: User,
-  issuerRepo: Repository<Issuer>,
+  manager: EntityManager,
   templateId: number,
 ) => {
-  const issuer = await issuerRepo.findOne({
+  const issuer = await manager.findOne(Issuer, {
     where: {
       user,
       template: {
@@ -45,13 +45,12 @@ export const isTemplateIssuer = async (
  */
 export const isTemplateEditorOrIssuer = async (
   user: User,
-  editorRepo: Repository<Editor>,
-  issuerRepo: Repository<Issuer>,
+  manager: EntityManager,
   templateId: number,
 ) => {
   return (
-    (await isTemplateEditor(user, editorRepo, templateId)) ||
-    (await isTemplateIssuer(user, issuerRepo, templateId))
+    (await isTemplateEditor(user, manager, templateId)) ||
+    (await isTemplateIssuer(user, manager, templateId))
   )
 }
 

--- a/backend/src/users/users.controller.spec.ts
+++ b/backend/src/users/users.controller.spec.ts
@@ -1,14 +1,13 @@
 import { Test, TestingModule } from '@nestjs/testing'
 import { UsersController } from './users.controller'
 import { UsersService } from './users.service'
-import { getRepositoryToken } from '@nestjs/typeorm'
-import { Template, TemplateVersion, Editor, Issuer } from 'database/entities'
+import { getConnectionToken } from '@nestjs/typeorm'
 import { MemosService } from 'memos/memos.service'
 import { TemplatesService } from 'templates/templates.service'
 
 describe('UsersController', () => {
   let controller: UsersController
-  const mockRepository = {}
+  const mockConnection = {}
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -19,20 +18,8 @@ describe('UsersController', () => {
         MemosService,
         TemplatesService,
         {
-          provide: getRepositoryToken(Template),
-          useValue: mockRepository,
-        },
-        {
-          provide: getRepositoryToken(TemplateVersion),
-          useValue: mockRepository,
-        },
-        {
-          provide: getRepositoryToken(Editor),
-          useValue: mockRepository,
-        },
-        {
-          provide: getRepositoryToken(Issuer),
-          useValue: mockRepository,
+          provide: getConnectionToken(),
+          useValue: mockConnection,
         },
       ],
     }).compile()

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -1,13 +1,12 @@
 import { Test, TestingModule } from '@nestjs/testing'
-import { getRepositoryToken } from '@nestjs/typeorm'
-import { Template, TemplateVersion, Editor, Issuer } from 'database/entities'
+import { getConnectionToken } from '@nestjs/typeorm'
 import { MemosService } from 'memos/memos.service'
 import { TemplatesService } from 'templates/templates.service'
 import { UsersService } from './users.service'
 
 describe('UsersService', () => {
   let service: UsersService
-  const mockRepository = {}
+  const mockConnection = {}
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -17,20 +16,8 @@ describe('UsersService', () => {
         MemosService,
         TemplatesService,
         {
-          provide: getRepositoryToken(Template),
-          useValue: mockRepository,
-        },
-        {
-          provide: getRepositoryToken(TemplateVersion),
-          useValue: mockRepository,
-        },
-        {
-          provide: getRepositoryToken(Editor),
-          useValue: mockRepository,
-        },
-        {
-          provide: getRepositoryToken(Issuer),
-          useValue: mockRepository,
+          provide: getConnectionToken(),
+          useValue: mockConnection,
         },
       ],
     }).compile()


### PR DESCRIPTION
## Context

Injecting individual repositories results in separate transactions for each entity, which defeats the purpose of a transaction. 

## Approach

Inject a connection and use a common manager for transactions. 

## Tests

Insert a new template, observe that a single transaction is used and rollbacks work correctly. 