### PR TITLE
feat: parse template body blocks

### DIFF
--- a/backend/src/templates/templates.service.ts
+++ b/backend/src/templates/templates.service.ts
@@ -19,7 +19,7 @@ import {
   UpdateTemplateDto,
   UpdateTemplateResponseDto,
 } from './dto'
-import { isTemplateEditorOrIssuer } from './templates.util'
+import { isTemplateEditorOrIssuer, parseTemplate } from './templates.util'
 
 @Injectable()
 export class TemplatesService {
@@ -42,12 +42,16 @@ export class TemplatesService {
       await manager.save(template)
 
       // Create template version
+      const paramsRequired = body.flatMap((block) => {
+        if (typeof block.data !== 'string') return []
+        return parseTemplate(block.data)
+      })
       const templateVersion = manager.create(TemplateVersion, {
         template,
         editor: author,
         version: 1, // new template, first version
         body,
-        paramsRequired: [], // TODO fix once templating service is implemented
+        paramsRequired,
       })
       await manager.save(templateVersion)
 


### PR DESCRIPTION
## Context

Basic template parsing merged in #58, replace placeholder with implementation. 

## Approach

All string-type blocks should support parameters. Map each block's data to a set of required params and flatten it into the final array of required parameters. 

## Tests

Call the template creation endpoint, check that `params_required` contains the necessary parameters across all template blocks. 
