### PR TITLE
fix: ignore uin and uin_type on template params

### DIFF
--- a/backend/src/memos/memos.service.ts
+++ b/backend/src/memos/memos.service.ts
@@ -26,7 +26,7 @@ export class MemosService {
     /*
     1. Check template status
       b. If not public, fail.
-    2. Check if user is an issuer.  
+    2. Check if user is an issuer.
     3. Check if versionId exists, if not, retrieve latest version
     4. Retrieve template version
       a. body, paramsRequired
@@ -148,7 +148,11 @@ export class MemosService {
       if (typeof block.data !== 'string') return block
       return {
         ...block,
-        data: renderTemplate(block.data, { ...params, uin: memo.uin }),
+        data: renderTemplate(block.data, {
+          ...params,
+          uin: memo.uin,
+          uin_type: memo.uinType,
+        }),
       }
     })
 

--- a/backend/src/templates/templates.util.ts
+++ b/backend/src/templates/templates.util.ts
@@ -67,7 +67,9 @@ export const parseTemplate = (body: string): Array<string> => {
   for (const meta of parsed) {
     const type = meta[0]
     const token = meta[1]
-    if (type === 'name') {
+
+    // uin and uin_type are required properties of the memo and should not be included in the params
+    if (type === 'name' && token !== 'uin' && token !== 'uin_type') {
       const key = token.toLowerCase()
       if (!key) {
         // TODO: throw an error? This currently ignores empty keys


### PR DESCRIPTION
## Context

`parseTemplate` picks up `uin` as a param, create memo endpoint complains about `uin` param missing. 

## Approach

When parsing the template, ignore `uin` and `uin_type` as params -- those are required on the memo. 

## Tests

Create a template with `{{ uin }}` and/or `{{ uin_type }}`, check that they aren't picked up as required params in the db. 
