### PR TITLE
Feat/display memos page

### DIFF
--- a/backend/src/memos/dto/get-memo.dto.ts
+++ b/backend/src/memos/dto/get-memo.dto.ts
@@ -16,3 +16,17 @@ export class GetMemoResponseDto {
 
   body!: TemplateBlock[]
 }
+
+export class GetMemoMetaResponseDto {
+  id!: number
+  issuer!: User
+  slug!: string
+  createdAt!: Date // issued at
+
+  template!: string // Name of template for this memo
+
+  // Details that we might eventually want to display on dashboard.
+  // expiresAt?: Date
+  // isViewed!: boolean
+  // isVoid!: boolean
+}

--- a/backend/src/users/dto/list-memos-for-user.dto.ts
+++ b/backend/src/users/dto/list-memos-for-user.dto.ts
@@ -2,6 +2,7 @@ export class ListMemosForUserDto {
   templateId!: number
   /**
    * If version is not supplied, defaults to retrieving latest version of template
+   * Comment: Shouldn't we retrieve all memos regardless of version instead?
    */
   version?: number
   page?: number = 1

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get, Param, Query, UseGuards } from '@nestjs/common'
 import { ApiResponse, ApiTags } from '@nestjs/swagger'
 import { AuthGuard } from 'auth/auth.guard'
+import { GetMemoMetaResponseDto } from 'memos/dto'
 import { GetTemplateMetaResponseDto } from 'templates/dto'
 import { ListMemosForUserDto } from './dto'
 import { UsersService } from './users.service'
@@ -25,11 +26,12 @@ export class UsersController {
    * List memos that the user has access to
    */
   @Get(':id/memos')
-  @ApiResponse({ type: ListMemosForUserDto })
+  @ApiResponse({ type: [GetMemoMetaResponseDto] })
   async listMemos(
     @Param('id') _userId: number,
-    @Query('query') _query: ListMemosForUserDto,
-  ): Promise<void> {
-    await this.usersService.listMemos()
+    @Query() _query: ListMemosForUserDto,
+  ): Promise<GetMemoMetaResponseDto[]> {
+    const result = await this.usersService.listMemos(_userId, _query)
+    return result
   }
 }

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -2,14 +2,21 @@ import { Injectable } from '@nestjs/common'
 import { TemplatesService } from 'templates/templates.service'
 import { MemosService } from 'memos/memos.service'
 import { GetTemplateMetaResponseDto } from 'templates/dto'
+import { ListMemosForUserDto } from './dto'
+import { GetMemoMetaResponseDto } from 'memos/dto'
 @Injectable()
 export class UsersService {
   constructor(
     private memosService: MemosService,
     private templatesService: TemplatesService,
   ) {}
-  async listMemos(): Promise<void> {
-    this.memosService.listMemosForUser()
+
+  async listMemos(
+    userId: number,
+    query: ListMemosForUserDto,
+  ): Promise<GetMemoMetaResponseDto[]> {
+    const result = this.memosService.listMemosForUser(userId, query)
+    return result
   }
   async listTemplates(userId: number): Promise<GetTemplateMetaResponseDto[]> {
     const result = this.templatesService.listTemplatesForUser(userId)

--- a/frontend/src/pages/dashboard/Dashboard.tsx
+++ b/frontend/src/pages/dashboard/Dashboard.tsx
@@ -12,12 +12,13 @@ export const Dashboard = (): JSX.Element => {
       <Flex h="100%" w="100%" overflow="auto" direction="row">
         <Tabs isFitted orientation="vertical" w="100%">
           <TabList
-            px={{ base: '0.5rem', md: '0.75rem', lg: '1rem' }}
+            // px={{ base: '0.5rem', md: '0.75rem', lg: '1rem' }}
             w={{ base: '20ch' }}
             gridArea="tabs"
             borderBottom="none"
             justifyContent={{ base: 'flex-start', lg: 'center' }}
             alignSelf="flex-start"
+            alignItems="stretch"
           >
             <Tab>All Templates</Tab>
             <Tab>All Memos</Tab>

--- a/frontend/src/pages/dashboard/Dashboard.tsx
+++ b/frontend/src/pages/dashboard/Dashboard.tsx
@@ -27,7 +27,7 @@ export const Dashboard = (): JSX.Element => {
             <TabPanel padding="0">
               <TemplatesPage />
             </TabPanel>
-            <TabPanel>
+            <TabPanel padding="0">
               <MemosPage />
             </TabPanel>
           </TabPanels>

--- a/frontend/src/pages/dashboard/Dashboard.tsx
+++ b/frontend/src/pages/dashboard/Dashboard.tsx
@@ -23,7 +23,7 @@ export const Dashboard = (): JSX.Element => {
             <Tab>All Templates</Tab>
             <Tab>All Memos</Tab>
           </TabList>
-          <TabPanels bg="neutral.200">
+          <TabPanels bg="neutral.100">
             <TabPanel padding="0">
               <TemplatesPage />
             </TabPanel>

--- a/frontend/src/pages/dashboard/DashboardService.ts
+++ b/frontend/src/pages/dashboard/DashboardService.ts
@@ -15,13 +15,33 @@ export class TemplateMetaResponseDto {
   updatedAt!: Date
 }
 
+export class MemoMetaResponseDto {
+  id!: number
+  issuer!: number // Name?
+  slug!: string
+  createdAt!: Date // issued at
+
+  template!: string // Name of template for this memo
+}
+
 /**
- * Gets metadata for all templates in dashboard view i.e. forms which user
+ * Gets metadata for all templates in dashboard view i.e. templates which user
  * owns or collaborates on
- * @returns Metadata required for forms on dashboard view
+ * @returns Metadata required for templates on dashboard view
  */
 export const getTemplatesView = async (
   userId: number,
 ): Promise<TemplateMetaResponseDto[]> => {
   return UsersApi.url(`/${userId}/templates`).get().json()
+}
+
+/**
+ * Gets metadata for all memos in dashboard view i.e. memos which user
+ * has issued
+ * @returns Metadata required for memos on dashboard view
+ */
+export const getMemosView = async (
+  userId: number,
+): Promise<MemoMetaResponseDto[]> => {
+  return UsersApi.url(`/${userId}/memos`).get().json()
 }

--- a/frontend/src/pages/memos/MemosPage.tsx
+++ b/frontend/src/pages/memos/MemosPage.tsx
@@ -1,14 +1,102 @@
-import { Link } from 'react-router-dom'
-import { Button, Flex } from '@chakra-ui/react'
+import { useCallback, useMemo } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import { Box, Container, Grid } from '@chakra-ui/react'
+import { chunk } from 'lodash'
 
-import { BUILDER_ROUTE } from '~constants/routes'
+import Pagination from '~components/Pagination'
+
+import { MemoHeader } from './components/MemoHeader'
+import { MemoRows } from './components/MemoRows'
+import { useMemosDashboard } from './queries'
+
+export const CONTAINER_MAXW = '120rem'
+const PAGE_DEFAULTS = {
+  size: 10,
+  pageNumber: 1,
+}
+
+const useMemosPage = () => {
+  const { data: dashboardMemos, isLoading } = useMemosDashboard()
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  const currentPage = Number(
+    searchParams.get('page') ?? PAGE_DEFAULTS.pageNumber,
+  )
+  const pageSize = Number(searchParams.get('size') ?? PAGE_DEFAULTS.size)
+
+  const setPageNumber = useCallback(
+    (page: number) => {
+      setSearchParams({ page: String(page) })
+    },
+    [setSearchParams],
+  )
+
+  const chunkedData = useMemo(
+    () => chunk(dashboardMemos, pageSize),
+    [pageSize, dashboardMemos],
+  )
+
+  const paginatedData = useMemo(() => {
+    if (currentPage < 1 || currentPage > chunkedData.length) {
+      return []
+    }
+    return chunkedData[currentPage - 1]
+  }, [chunkedData, currentPage])
+
+  return {
+    isLoading: isLoading,
+    currentPage,
+    totalMemoCount: dashboardMemos?.length,
+    paginatedData,
+    setPageNumber,
+  }
+}
 
 export const MemosPage = (): JSX.Element => {
+  const {
+    isLoading,
+    totalMemoCount,
+    paginatedData,
+    currentPage,
+    setPageNumber,
+  } = useMemosPage()
+
   return (
-    <Flex flex={1} bg="neutral.200">
-      <Link to={BUILDER_ROUTE}>
-        <Button>Create a memo</Button>
-      </Link>
-    </Flex>
+    <Grid
+      flex={1}
+      bg="neutral.100"
+      templateColumns="1fr"
+      templateRows="auto 1fr auto"
+      templateAreas="'header' 'main' 'footer'"
+    >
+      <Container
+        gridArea="header"
+        maxW={CONTAINER_MAXW}
+        borderBottom="1px solid var(--chakra-colors-neutral-300)"
+        px="2rem"
+        py="1rem"
+      >
+        <MemoHeader isLoading={isLoading} />
+      </Container>
+      <Box gridArea="main">
+        <Box />
+        <MemoRows rows={paginatedData} isLoading={isLoading} />
+      </Box>
+      <Container
+        gridArea="footer"
+        py={{ base: '1rem', md: '3rem' }}
+        px="2rem"
+        maxW={CONTAINER_MAXW}
+        borderTop="1px solid var(--chakra-colors-neutral-300)"
+      >
+        <Pagination
+          isDisabled={isLoading}
+          currentPage={currentPage}
+          totalCount={totalMemoCount ?? 0}
+          onPageChange={setPageNumber}
+          pageSize={PAGE_DEFAULTS.size}
+        />
+      </Container>
+    </Grid>
   )
 }

--- a/frontend/src/pages/memos/components/MemoHeader.tsx
+++ b/frontend/src/pages/memos/components/MemoHeader.tsx
@@ -1,0 +1,40 @@
+import { BiPlus } from 'react-icons/bi'
+import { Link } from 'react-router-dom'
+import { Stack, Text, useBreakpointValue } from '@chakra-ui/react'
+
+import { BUILDER_ROUTE } from '~constants/routes'
+import Button from '~components/Button'
+
+export interface MemoHeaderProps {
+  isLoading: boolean
+}
+
+/**
+ * Header for listing number of forms, or updating the sort order of listed forms, etc.
+ */
+export const MemoHeader = ({ isLoading }: MemoHeaderProps): JSX.Element => {
+  const isMobile = useBreakpointValue({
+    base: true,
+    xs: true,
+    md: false,
+  })
+
+  return (
+    <Stack
+      justify="space-between"
+      direction={{ base: 'column', md: 'row' }}
+      align={{ base: 'flex-start', md: 'center' }}
+      spacing="1rem"
+    >
+      <Text
+        flex={1}
+        as="h2"
+        textStyle="h2"
+        display="flex"
+        color="secondary.500"
+      >
+        Issued by You
+      </Text>
+    </Stack>
+  )
+}

--- a/frontend/src/pages/memos/components/MemoHeader.tsx
+++ b/frontend/src/pages/memos/components/MemoHeader.tsx
@@ -1,9 +1,4 @@
-import { BiPlus } from 'react-icons/bi'
-import { Link } from 'react-router-dom'
-import { Stack, Text, useBreakpointValue } from '@chakra-ui/react'
-
-import { BUILDER_ROUTE } from '~constants/routes'
-import Button from '~components/Button'
+import { Stack, Text } from '@chakra-ui/react'
 
 export interface MemoHeaderProps {
   isLoading: boolean
@@ -13,12 +8,6 @@ export interface MemoHeaderProps {
  * Header for listing number of forms, or updating the sort order of listed forms, etc.
  */
 export const MemoHeader = ({ isLoading }: MemoHeaderProps): JSX.Element => {
-  const isMobile = useBreakpointValue({
-    base: true,
-    xs: true,
-    md: false,
-  })
-
   return (
     <Stack
       justify="space-between"

--- a/frontend/src/pages/memos/components/MemoRow.tsx
+++ b/frontend/src/pages/memos/components/MemoRow.tsx
@@ -1,0 +1,98 @@
+import { useMemo } from 'react'
+import {
+  Box,
+  ButtonProps,
+  chakra,
+  Flex,
+  Text,
+  useBreakpointValue,
+} from '@chakra-ui/react'
+import dayjs from 'dayjs'
+
+import { MemoMetaResponseDto } from '~/pages/dashboard/DashboardService'
+
+import { useRowActionDropdown } from './RowActions/useRowActionDropdown'
+import { RowActions } from './RowActions'
+
+export interface MemoRowProps extends ButtonProps {
+  memoMeta: MemoMetaResponseDto
+}
+
+const RELATIVE_DATE_FORMAT = {
+  sameDay: '[today,] D MMM h:mma', // today, 16 Jun 9:30am
+  nextDay: '[tomorrow,] D MMM h:mma', // tomorrow, 16 Jun 9:30am
+  lastDay: '[yesterday,] D MMM h:mma', // yesterday, 16 Jun 9:30am
+  nextWeek: 'ddd, D MMM YYYY h:mma', // Tue, 17 Oct 2021 9:30pm
+  lastWeek: 'ddd, D MMM YYYY h:mma', // Tue, 17 Oct 2021 9:30pm
+  sameElse: 'D MMM YYYY h:mma', // 6 Oct 2021 9:30pm
+}
+
+export const MemoRow = ({
+  memoMeta,
+  ...buttonProps
+}: MemoRowProps): JSX.Element => {
+  const prettyIssuedDate = useMemo(() => {
+    return dayjs(memoMeta.createdAt).calendar(null, RELATIVE_DATE_FORMAT)
+  }, [memoMeta.createdAt])
+
+  const { handleViewMemo } = useRowActionDropdown(memoMeta.id, memoMeta.slug)
+
+  const isTruncated = useBreakpointValue({
+    base: false,
+    md: true,
+  })
+
+  return (
+    <Box pos="relative">
+      <chakra.button
+        transitionProperty="common"
+        transitionDuration="normal"
+        onClick={handleViewMemo}
+        w="100%"
+        py="1.5rem"
+        display="grid"
+        justifyContent="space-between"
+        gridTemplateColumns={{
+          base: '1fr 2.75rem',
+          md: '1fr min-content 8rem',
+        }}
+        gridTemplateRows={{ base: 'auto 2.75rem', md: 'auto' }}
+        gridTemplateAreas={{
+          base: "'title title' 'status actions'",
+          md: "'title status actions'",
+        }}
+        gridGap={{ base: '0.5rem', md: '1.5rem' }}
+        _hover={{
+          bg: 'primary.100',
+        }}
+        _active={{
+          bg: 'primary.200',
+        }}
+        _focus={{
+          boxShadow: '0 0 0 2px var(--chakra-colors-primary-500)',
+        }}
+        {...buttonProps}
+      >
+        <Flex flexDir="column" gridArea="title" textAlign="initial">
+          <Text
+            isTruncated={isTruncated}
+            title={memoMeta.template}
+            textStyle="subhead-1"
+            color="secondary.700"
+          >
+            {memoMeta.template}
+          </Text>
+          <Text textStyle="body-2" color="secondary.400">
+            Issued {prettyIssuedDate}
+          </Text>
+        </Flex>
+        <Box gridArea="status" alignSelf="center">
+          {/*Issued X times*/}
+        </Box>
+        {/* Blank spacing for absolutely positioned RowActions component */}
+        <Box gridArea="actions" />
+      </chakra.button>
+      <RowActions memoId={memoMeta.id} slug={memoMeta.slug} />
+    </Box>
+  )
+}

--- a/frontend/src/pages/memos/components/MemoRows.tsx
+++ b/frontend/src/pages/memos/components/MemoRows.tsx
@@ -1,0 +1,32 @@
+import { Divider, Spinner, Stack } from '@chakra-ui/react'
+
+import { MemoMetaResponseDto } from '~/pages/dashboard/DashboardService'
+
+import { CONTAINER_MAXW } from '../MemosPage'
+
+import { MemoRow } from './MemoRow'
+
+export interface MemoRowsProps {
+  rows: MemoMetaResponseDto[]
+  isLoading: boolean
+}
+
+export const MemoRows = ({ rows, isLoading }: MemoRowsProps): JSX.Element => {
+  if (isLoading) {
+    return (
+      <Spinner thickness="4px" speed="0.65s" emptyColor="gray.200" size="xl" />
+    )
+  }
+  return (
+    <Stack
+      maxW={CONTAINER_MAXW}
+      m="auto"
+      spacing={0}
+      divider={<Divider borderColor="neutral.300" />}
+    >
+      {rows.map((meta) => (
+        <MemoRow px="2rem" key={meta.id} memoMeta={meta} />
+      ))}
+    </Stack>
+  )
+}

--- a/frontend/src/pages/memos/components/RowActions/RowActions.tsx
+++ b/frontend/src/pages/memos/components/RowActions/RowActions.tsx
@@ -1,0 +1,22 @@
+import { Box } from '@chakra-ui/react'
+
+import { RowActionsDropdown } from './RowActionsDropdown'
+
+export interface RowActionsProps {
+  memoId: number
+  slug: string
+  isDisabled?: boolean
+}
+
+export const RowActions = (props: RowActionsProps): JSX.Element => {
+  return (
+    <Box
+      pos="absolute"
+      right="2em"
+      top={{ md: '1.5rem' }}
+      bottom={{ base: '1.5rem', md: 'initial' }}
+    >
+      <RowActionsDropdown {...props} />
+    </Box>
+  )
+}

--- a/frontend/src/pages/memos/components/RowActions/RowActionsDropdown.tsx
+++ b/frontend/src/pages/memos/components/RowActions/RowActionsDropdown.tsx
@@ -1,0 +1,81 @@
+import {
+  BiBlock,
+  BiChevronDown,
+  BiChevronUp,
+  BiCopy,
+  BiDownload,
+} from 'react-icons/bi'
+import { ButtonGroup, MenuButton, MenuDivider } from '@chakra-ui/react'
+
+import Button from '~components/Button'
+import IconButton from '~components/IconButton'
+import Menu from '~components/Menu'
+
+import { RowActionsProps } from './RowActions'
+import { useRowActionDropdown } from './useRowActionDropdown'
+
+export const RowActionsDropdown = ({
+  isDisabled,
+  memoId,
+  slug,
+}: RowActionsProps): JSX.Element => {
+  const {
+    handleViewMemo,
+    handleCopyWeblink,
+    handleDownloadCsv,
+    handleVoidMemo,
+  } = useRowActionDropdown(memoId, slug)
+
+  return (
+    <Menu
+      placement="bottom-end"
+      // Prevents massize render load when there are a ton of rows
+      isLazy
+    >
+      {({ isOpen }) => (
+        <>
+          <ButtonGroup
+            isAttached
+            variant="outline"
+            colorScheme="secondary"
+            display={{ base: 'none', md: 'flex' }}
+          >
+            <Button px="1.5rem" mr="-1px" onClick={handleViewMemo}>
+              View
+            </Button>
+            <MenuButton
+              as={IconButton}
+              isDisabled={isDisabled}
+              _active={{ bg: 'secondary.100' }}
+              isActive={isOpen}
+              aria-label="More actions"
+              icon={isOpen ? <BiChevronUp /> : <BiChevronDown />}
+            />
+          </ButtonGroup>
+          <Menu.List>
+            <Menu.Item
+              onClick={handleCopyWeblink}
+              icon={<BiCopy fontSize="1.25rem" />}
+            >
+              Copy Weblink
+            </Menu.Item>
+            <Menu.Item
+              onClick={handleDownloadCsv}
+              icon={<BiDownload fontSize="1.25rem" />}
+            >
+              Download CSV
+            </Menu.Item>
+            <MenuDivider />
+            <Menu.Item
+              onClick={handleVoidMemo}
+              color="danger.500"
+              icon={<BiBlock fontSize="1.25rem" />}
+            >
+              Void
+            </Menu.Item>
+          </Menu.List>
+        </>
+      )}
+    </Menu>
+  )
+}

--- a/frontend/src/pages/memos/components/RowActions/index.ts
+++ b/frontend/src/pages/memos/components/RowActions/index.ts
@@ -1,0 +1,1 @@
+export { RowActions } from './RowActions'

--- a/frontend/src/pages/memos/components/RowActions/useRowActionDropdown.ts
+++ b/frontend/src/pages/memos/components/RowActions/useRowActionDropdown.ts
@@ -1,4 +1,5 @@
 import { useNavigate } from 'react-router-dom'
+import { useToast } from '@chakra-ui/react'
 
 type UseRowActionDropdownReturn = {
   handleViewMemo: () => void
@@ -12,10 +13,22 @@ export const useRowActionDropdown = (
   slug: string,
 ): UseRowActionDropdownReturn => {
   const navigate = useNavigate()
+  const toast = useToast()
+  const handleCopyWeblink = async () => {
+    const { protocol, hostname, port } = new URL(window.location.href)
+    await navigator.clipboard.writeText(
+      `${protocol}//${hostname}:${port}/p/${slug}`,
+    )
+
+    toast({
+      title: 'Weblink copied to clipboard',
+      position: 'top',
+      status: 'success',
+    })
+  }
   return {
     handleViewMemo: () => navigate(`/p/${slug}`),
-    handleCopyWeblink: () =>
-      console.log(`copy weblink button clicked for memo id: ${memoId}`),
+    handleCopyWeblink: handleCopyWeblink,
     handleDownloadCsv: () =>
       console.log(`download csv button clicked for memo id: ${memoId}`),
     handleVoidMemo: () =>

--- a/frontend/src/pages/memos/components/RowActions/useRowActionDropdown.ts
+++ b/frontend/src/pages/memos/components/RowActions/useRowActionDropdown.ts
@@ -1,0 +1,24 @@
+import { useNavigate } from 'react-router-dom'
+
+type UseRowActionDropdownReturn = {
+  handleViewMemo: () => void
+  handleCopyWeblink: () => void
+  handleDownloadCsv: () => void
+  handleVoidMemo: () => void
+}
+
+export const useRowActionDropdown = (
+  memoId: number,
+  slug: string,
+): UseRowActionDropdownReturn => {
+  const navigate = useNavigate()
+  return {
+    handleViewMemo: () => navigate(`/p/${slug}`),
+    handleCopyWeblink: () =>
+      console.log(`copy weblink button clicked for memo id: ${memoId}`),
+    handleDownloadCsv: () =>
+      console.log(`download csv button clicked for memo id: ${memoId}`),
+    handleVoidMemo: () =>
+      console.log(`void memo button clicked for memo id: ${memoId}`),
+  }
+}

--- a/frontend/src/pages/memos/queries.ts
+++ b/frontend/src/pages/memos/queries.ts
@@ -1,0 +1,19 @@
+import { useQuery, UseQueryResult } from 'react-query'
+
+import {
+  getMemosView,
+  MemoMetaResponseDto,
+} from '~/pages/dashboard/DashboardService'
+
+import { useAuth } from '~features/auth/AuthContext'
+
+const memosKeys = {
+  all: ['memos'] as const,
+}
+
+export const useMemosDashboard = (): UseQueryResult<MemoMetaResponseDto[]> => {
+  const { user } = useAuth()
+  return useQuery(memosKeys.all, () => getMemosView(user.id), {
+    staleTime: 5000,
+  })
+}

--- a/frontend/src/pages/templates/TemplatesPage.tsx
+++ b/frontend/src/pages/templates/TemplatesPage.tsx
@@ -11,7 +11,7 @@ import { useTemplatesDashboard } from './queries'
 
 export const CONTAINER_MAXW = '120rem'
 const PAGE_DEFAULTS = {
-  size: 5,
+  size: 10,
   pageNumber: 1,
 }
 
@@ -67,7 +67,6 @@ export const TemplatesPage = (): JSX.Element => {
       bg="neutral.100"
       templateColumns="1fr"
       templateRows="auto 1fr auto"
-      // minH="93vh" // TODO: Minus the nav bar (6vh) Don't hardcode.
       templateAreas="'header' 'main' 'footer'"
     >
       <Container

--- a/frontend/src/pages/templates/TemplatesPage.tsx
+++ b/frontend/src/pages/templates/TemplatesPage.tsx
@@ -67,7 +67,7 @@ export const TemplatesPage = (): JSX.Element => {
       bg="neutral.100"
       templateColumns="1fr"
       templateRows="auto 1fr auto"
-      minH="92vh" // TODO: Minus the nav bar (6vh) Don't hardcode.
+      // minH="93vh" // TODO: Minus the nav bar (6vh) Don't hardcode.
       templateAreas="'header' 'main' 'footer'"
     >
       <Container


### PR DESCRIPTION
## Context

Adds a memos page where the issuer can view all their issued memos.

## Approach

This is pretty much the same as the all templates page.

**Features**:

View memo and copy weblink works, void and download CSV are not implemented yet.
There is currently no option to filter by template or version.
The data fetching for memos is not paginated yet.

## Screenshots

![image](https://user-images.githubusercontent.com/40933287/150948950-a2bce0dd-c704-4581-9bdf-72a3c394aa24.png)


