### PR TITLE
Feat/update templates

### DIFF
--- a/backend/src/templates/templates.controller.ts
+++ b/backend/src/templates/templates.controller.ts
@@ -5,12 +5,10 @@ import {
   Param,
   Post,
   Put,
-  Res,
   Session,
   UseGuards,
 } from '@nestjs/common'
 import { ApiCreatedResponse, ApiResponse, ApiTags } from '@nestjs/swagger'
-import { Response } from 'express'
 import {
   AddPermissionDto,
   AddPermissionResponseDto,
@@ -76,16 +74,17 @@ export class TemplatesController {
   @Put(':id')
   @ApiResponse({ type: UpdateTemplateResponseDto })
   async updateTemplate(
-    @Res() res: Response,
+    @Session() session: SessionData,
     @Param('id') templateId: number,
     @Body() updateTemplateDto: UpdateTemplateDto,
-  ): Promise<void> {
-    const result = await this.templatesService.updateTemplate({
+  ): Promise<UpdateTemplateResponseDto> {
+    const result = await this.templatesService.updateTemplate(session.user, {
       ...updateTemplateDto,
       templateId,
     })
-    res.json(result)
+    return result
   }
+
   /**
    * Hide all versions of a template by id such that the template is no longer displayed
    * and cannot be used for issuance

--- a/backend/src/templates/templates.service.ts
+++ b/backend/src/templates/templates.service.ts
@@ -135,8 +135,8 @@ export class TemplatesService {
         version += 1 // Bump up version number
         const templateVersion = manager.create(TemplateVersion, {
           template: { id: templateId },
-          editor: editor,
-          version: version,
+          editor,
+          version,
           body,
           paramsRequired,
         })

--- a/backend/src/templates/templates.service.ts
+++ b/backend/src/templates/templates.service.ts
@@ -1,4 +1,5 @@
 import {
+  ConflictException,
   ForbiddenException,
   Injectable,
   NotFoundException,
@@ -10,7 +11,7 @@ import {
   TemplateVersion,
   User,
 } from 'database/entities'
-import { union } from 'lodash'
+import { isEqual, union } from 'lodash'
 import { Connection, In } from 'typeorm'
 import { TemplateStatus } from 'types'
 import {
@@ -21,7 +22,11 @@ import {
   UpdateTemplateDto,
   UpdateTemplateResponseDto,
 } from './dto'
-import { isTemplateEditorOrIssuer, parseTemplate } from './templates.util'
+import {
+  isTemplateEditor,
+  isTemplateEditorOrIssuer,
+  parseTemplate,
+} from './templates.util'
 
 @Injectable()
 export class TemplatesService {
@@ -75,11 +80,86 @@ export class TemplatesService {
   }
 
   async updateTemplate(
+    editor: User,
     _data: UpdateTemplateDto & { templateId: number },
   ): Promise<UpdateTemplateResponseDto> {
-    // Do something with data
-    return { id: 1, version: 2 }
+    const { name, body, templateId } = _data
+
+    // Check that there is a template version to actually update
+    const oldVersion = await this.connection.manager.findOne(TemplateVersion, {
+      where: {
+        template: { id: templateId },
+        isLatestVersion: true,
+      },
+      relations: ['template'],
+    })
+
+    if (!oldVersion) {
+      throw new NotFoundException('Template to update not found.')
+    }
+
+    // Check if user is editor.
+    const isAllowed = await isTemplateEditor(
+      editor,
+      this.connection.manager,
+      templateId,
+    )
+
+    if (!isAllowed) {
+      throw new ForbiddenException('User has no edit permissions.')
+    }
+
+    // If no changes, return as is.
+    if (isEqual(oldVersion.body, body) && oldVersion.template.name == name) {
+      return { id: oldVersion.template.id, version: oldVersion.version }
+    }
+
+    return this.connection.transaction(async (manager) => {
+      // Update the template name if required.
+      if (oldVersion.template.name !== name) {
+        const updatedTemplate = await manager.update(Template, templateId, {
+          name,
+        })
+        if (!updatedTemplate.affected) {
+          throw new ConflictException()
+        }
+      }
+
+      let version = oldVersion.version
+      if (!isEqual(oldVersion.body, body)) {
+        // Deprecate old version
+        const updatedVersion = await manager.update(
+          TemplateVersion,
+          oldVersion.id,
+          {
+            isLatestVersion: false,
+          },
+        )
+        if (!updatedVersion.affected) {
+          // Updating old template verion failed.
+          throw new ConflictException()
+        }
+
+        // Create new template version
+        const paramsRequired = body.flatMap((block) => {
+          if (typeof block.data !== 'string') return []
+          return parseTemplate(block.data)
+        })
+        version += 1 // Bump up version number
+        const templateVersion = manager.create(TemplateVersion, {
+          template: { id: templateId },
+          editor: editor,
+          version: version,
+          body,
+          paramsRequired,
+        })
+        await manager.save(templateVersion)
+      }
+
+      return { id: templateId, version }
+    })
   }
+
   async hideTemplate(_templateId: number): Promise<void> {
     return
   }

--- a/frontend/src/features/builder/BuilderService.ts
+++ b/frontend/src/features/builder/BuilderService.ts
@@ -13,6 +13,13 @@ export const saveTemplate = async (data: SaveTemplateProps): Promise<void> => {
   return TemplatesApi.url('/').post(data)
 }
 
+export const updateTemplate = async (
+  templateId: string,
+  data: SaveTemplateProps,
+): Promise<void> => {
+  return TemplatesApi.url(`/${templateId}`).put(data)
+}
+
 export interface GetTemplateProps {
   templateId: string
 }

--- a/frontend/src/features/builder/BuilderService.ts
+++ b/frontend/src/features/builder/BuilderService.ts
@@ -10,14 +10,14 @@ export interface SaveTemplateProps {
   body: Array<{ type: 'TEXT' | 'HEADER'; data: string }>
 }
 export const saveTemplate = async (data: SaveTemplateProps): Promise<void> => {
-  return TemplatesApi.url('/').post(data)
+  return TemplatesApi.url('/').post(data).res()
 }
 
 export const updateTemplate = async (
   templateId: string,
   data: SaveTemplateProps,
 ): Promise<void> => {
-  return TemplatesApi.url(`/${templateId}`).put(data)
+  return TemplatesApi.url(`/${templateId}`).put(data).res()
 }
 
 export interface GetTemplateProps {

--- a/frontend/src/features/builder/BuilderService.ts
+++ b/frontend/src/features/builder/BuilderService.ts
@@ -5,10 +5,15 @@ const TEMPLATES_ENDPOINT = '/templates'
 
 const TemplatesApi = ApiService.url(TEMPLATES_ENDPOINT)
 
+export enum TemplateBlockType {
+  Header = 'HEADER',
+  Text = 'TEXT',
+}
 export interface SaveTemplateProps {
   name: string
-  body: Array<{ type: 'TEXT' | 'HEADER'; data: string }>
+  body: Array<{ type: TemplateBlockType; data: string }>
 }
+
 export const saveTemplate = async (data: SaveTemplateProps): Promise<void> => {
   return TemplatesApi.url('/').post(data).res()
 }

--- a/frontend/src/features/builder/EditorContext.tsx
+++ b/frontend/src/features/builder/EditorContext.tsx
@@ -71,26 +71,19 @@ export const useProvideEditor = (): EditorContextProps => {
   }, [value])
 
   const saveTemplate = useCallback(async () => {
-    if (activeEditorId) {
-      return BuilderService.updateTemplate(activeEditorId, {
-        name: activeTemplateName,
-        body: [
-          {
-            type: 'TEXT',
-            data: activeEditorValue,
-          },
-        ],
-      })
-    }
-    return BuilderService.saveTemplate({
+    const saveTemplateDto = {
       name: activeTemplateName,
       body: [
         {
-          type: 'TEXT',
+          type: BuilderService.TemplateBlockType.Text,
           data: activeEditorValue,
         },
       ],
-    })
+    }
+    if (activeEditorId) {
+      return BuilderService.updateTemplate(activeEditorId, saveTemplateDto)
+    }
+    return BuilderService.saveTemplate(saveTemplateDto)
   }, [activeTemplateName, activeEditorId, activeEditorValue])
 
   return {

--- a/frontend/src/features/builder/EditorContext.tsx
+++ b/frontend/src/features/builder/EditorContext.tsx
@@ -71,6 +71,17 @@ export const useProvideEditor = (): EditorContextProps => {
   }, [value])
 
   const saveTemplate = useCallback(async () => {
+    if (activeEditorId) {
+      return BuilderService.updateTemplate(activeEditorId, {
+        name: activeTemplateName,
+        body: [
+          {
+            type: 'TEXT',
+            data: activeEditorValue,
+          },
+        ],
+      })
+    }
     return BuilderService.saveTemplate({
       name: activeTemplateName,
       body: [
@@ -80,7 +91,7 @@ export const useProvideEditor = (): EditorContextProps => {
         },
       ],
     })
-  }, [activeTemplateName, activeEditorValue])
+  }, [activeTemplateName, activeEditorId, activeEditorValue])
 
   return {
     status,

--- a/frontend/src/pages/builder/components/BuilderNavBar.tsx
+++ b/frontend/src/pages/builder/components/BuilderNavBar.tsx
@@ -98,7 +98,7 @@ export const BuilderNavBar = ({
             icon={<BiLeftArrowAlt />}
           />
         </Box>
-        <Box>
+        <Box flex={1}>
           <Input
             value={activeTemplateName}
             type="text"

--- a/frontend/src/pages/builder/components/BuilderNavBar.tsx
+++ b/frontend/src/pages/builder/components/BuilderNavBar.tsx
@@ -133,7 +133,7 @@ export const BuilderNavBar = ({
               disabled={true}
             />
             <Button onClick={handleSaveTemplateClick}>Save Template</Button>
-            <Button onClick={handleCreateMemoClick}>Create Memo</Button>
+            {/* <Button onClick={handleCreateMemoClick}>Create Memo</Button> */}
           </ButtonGroup>
         </Box>
       </Flex>

--- a/frontend/src/pages/builder/components/BuilderNavBarContainer.tsx
+++ b/frontend/src/pages/builder/components/BuilderNavBarContainer.tsx
@@ -23,7 +23,6 @@ const useBuilderNavBar = () => {
   }, [])
 
   const handleSaveTemplate = async () => {
-    console.log('save template button clicked')
     try {
       await saveTemplate()
       toast({
@@ -32,7 +31,6 @@ const useBuilderNavBar = () => {
         status: 'success',
       })
     } catch (err) {
-      // BUG: This doesn't catch the error if saveTemplate is rejected.
       toast({
         title: `Failed to save ${activeTemplateName}.`,
         position: 'top',

--- a/frontend/src/pages/builder/components/BuilderNavBarContainer.tsx
+++ b/frontend/src/pages/builder/components/BuilderNavBarContainer.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { useToast } from '@chakra-ui/react'
 
 import { DASHBOARD_ROUTE } from '~constants/routes'
 
@@ -9,7 +10,8 @@ import { BuilderNavBar } from './BuilderNavBar'
 
 const useBuilderNavBar = () => {
   const navigate = useNavigate()
-  const { saveTemplate } = useEditor()
+  const { activeTemplateName, saveTemplate } = useEditor()
+  const toast = useToast()
 
   const handleBackToDashboard = useCallback(
     (): void => navigate(DASHBOARD_ROUTE),
@@ -22,7 +24,22 @@ const useBuilderNavBar = () => {
 
   const handleSaveTemplate = async () => {
     console.log('save template button clicked')
-    return saveTemplate()
+    try {
+      await saveTemplate()
+      toast({
+        title: `${activeTemplateName} saved.`,
+        position: 'top',
+        status: 'success',
+      })
+    } catch (err) {
+      // BUG: This doesn't catch the error if saveTemplate is rejected.
+      toast({
+        title: `Failed to save ${activeTemplateName}.`,
+        position: 'top',
+        status: 'error',
+      })
+    }
+    navigate(DASHBOARD_ROUTE)
   }
 
   const handleCreateMemo = useCallback((): void => {


### PR DESCRIPTION
## Context

This PR adds the update template feature, including both FE and BE work.

On the frontend, clicking save redirects to dashboard and shows a failure/success toast.

On the backend, here's how the updating is done.
1. If no latest template version for the provided `templateId` exists, error.
2. If user is not an editor, error.
3. If provided name and body does not differ from the existing fields, returns the existing version.
4. If only name is changed, update `template.name`. No new `templateVersion` is created.
5. If template version is changed, then a new `templateVersion` will be created.

## Misc
1. Remove create memo button from the editor.
2. Make the template name input a little bigger to accommodate longer template names.
