### PR TITLE
feat: use textarea component to enable resizable inputs

### DIFF
--- a/frontend/src/pages/issue/IssueSingleMemoPage.tsx
+++ b/frontend/src/pages/issue/IssueSingleMemoPage.tsx
@@ -12,6 +12,7 @@ import {
   Input,
   Select,
   Spacer,
+  Textarea,
 } from '@chakra-ui/react'
 import { ArrowBack } from '@styled-icons/boxicons-regular'
 import { render } from 'mustache'
@@ -37,7 +38,7 @@ export const IssueSingleMemoPage = (): ReactElement => {
   const mutation = useMutation((data: CreateMemo) => createMemo(data))
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false)
 
-  const handleParamsChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleParamsChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const { name, value } = e.target
     setParams({
       ...params,
@@ -175,12 +176,14 @@ export const IssueSingleMemoPage = (): ReactElement => {
                     <Heading {...textStyles['subhead-2']} mb="2">
                       {key}
                     </Heading>
-                    <Input
+                    <Textarea
                       name={key}
                       value={params[key]}
                       onChange={handleParamsChange}
                       required
                       disabled={isSubmitting}
+                      resize="vertical"
+                      rows={1}
                     />
                   </Box>
                 ))}


### PR DESCRIPTION
## Context

Some parameters might be longer than a single line. 

## Approach

Use a vertically-resizable textarea with `rows={1}` by default instead of an input. 
