### PR TITLE
fix: remove lowercasing of parameters

### DIFF
--- a/backend/src/memos/memos.service.ts
+++ b/backend/src/memos/memos.service.ts
@@ -7,7 +7,12 @@ import {
 import { Template, TemplateVersion, User, Memo } from 'database/entities'
 import { randomBytes } from 'crypto'
 import { pick } from 'lodash'
-import { isTemplateIssuer, renderTemplate } from 'templates/templates.util'
+import {
+  isTemplateIssuer,
+  renderTemplate,
+  UIN_TOKEN,
+  UIN_TYPE_TOKEN,
+} from 'templates/templates.util'
 import { Connection } from 'typeorm'
 import { TemplateStatus } from 'types'
 
@@ -189,8 +194,8 @@ export class MemosService {
         ...block,
         data: renderTemplate(block.data, {
           ...params,
-          uin: memo.uin,
-          uin_type: memo.uinType,
+          [UIN_TOKEN]: memo.uin,
+          [UIN_TYPE_TOKEN]: memo.uinType,
         }),
       }
     })

--- a/backend/src/templates/templates.util.ts
+++ b/backend/src/templates/templates.util.ts
@@ -2,6 +2,9 @@ import { Editor, Issuer, User } from 'database/entities'
 import { EntityManager } from 'typeorm'
 import mustache from 'mustache'
 
+export const UIN_TOKEN = 'UIN'
+export const UIN_TYPE_TOKEN = 'UIN Type'
+
 /**
  * Checks whether a user is an editor of a template.
  */
@@ -69,13 +72,12 @@ export const parseTemplate = (body: string): Array<string> => {
     const token = meta[1]
 
     // uin and uin_type are required properties of the memo and should not be included in the params
-    if (type === 'name' && token !== 'uin' && token !== 'uin_type') {
-      const key = token.toLowerCase()
-      if (!key) {
+    if (type === 'name' && token !== UIN_TOKEN && token !== UIN_TYPE_TOKEN) {
+      if (!token) {
         // TODO: throw an error? This currently ignores empty keys
         continue
       }
-      vars.add(key)
+      vars.add(token)
     }
   }
 

--- a/frontend/src/pages/issue/IssueSingleMemoPage.tsx
+++ b/frontend/src/pages/issue/IssueSingleMemoPage.tsx
@@ -154,7 +154,7 @@ export const IssueSingleMemoPage = (): ReactElement => {
                   p="4"
                 >
                   <Heading {...textStyles['subhead-2']} mb="2">
-                    UIN
+                    {UIN_TOKEN}
                   </Heading>
                   <Input
                     value={uin}
@@ -172,7 +172,7 @@ export const IssueSingleMemoPage = (): ReactElement => {
                   p="4"
                 >
                   <Heading {...textStyles['subhead-2']} mb="2">
-                    UIN Type
+                    {UIN_TYPE_TOKEN}
                   </Heading>
                   <Select
                     placeholder="Choose a UIN type"

--- a/frontend/src/pages/issue/IssueSingleMemoPage.tsx
+++ b/frontend/src/pages/issue/IssueSingleMemoPage.tsx
@@ -25,6 +25,10 @@ import Spinner from '~components/Spinner'
 import { ReadonlyEditor } from '~pages/viewer/components/ReadonlyEditor'
 import { CreateMemo, createMemo } from '~features/memos/MemosService'
 
+// TODO share with backend
+const UIN_TOKEN = 'UIN'
+const UIN_TYPE_TOKEN = 'UIN Type'
+
 export const IssueSingleMemoPage = (): ReactElement => {
   const { templateId } = useParams()
   const { isLoading, isError, data: template } = useTemplate(Number(templateId))
@@ -79,8 +83,8 @@ export const IssueSingleMemoPage = (): ReactElement => {
   useEffect(() => {
     const paramsWithDefault: Record<string, string> = {
       ...params,
-      uin,
-      uin_type: uinType,
+      [UIN_TOKEN]: uin,
+      [UIN_TYPE_TOKEN]: uinType,
     }
     for (const key in paramsWithDefault) {
       if (!paramsWithDefault[key]) {


### PR DESCRIPTION
## Context

Lowercasing of parameters leads to user confusion and unnecessary complexity. 

## Approach

Remove all lowercasing of parameters, take parameter as-is. 
