### PR TITLE
fix: live preview bugs

### DIFF
--- a/frontend/src/pages/issue/IssueSingleMemoPage.tsx
+++ b/frontend/src/pages/issue/IssueSingleMemoPage.tsx
@@ -38,6 +38,8 @@ export const IssueSingleMemoPage = (): ReactElement => {
   const mutation = useMutation((data: CreateMemo) => createMemo(data))
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false)
 
+  const [previewParams, setPreviewParams] = useState<typeof params>({})
+
   const handleParamsChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const { name, value } = e.target
     setParams({
@@ -73,6 +75,20 @@ export const IssueSingleMemoPage = (): ReactElement => {
     const paramsFromTemplate = template?.paramsRequired || []
     setParams(Object.fromEntries(paramsFromTemplate.map((p) => [p, ''])))
   }, [template])
+
+  useEffect(() => {
+    const paramsWithDefault: Record<string, string> = {
+      ...params,
+      uin,
+      uin_type: uinType,
+    }
+    for (const key in paramsWithDefault) {
+      if (!paramsWithDefault[key]) {
+        paramsWithDefault[key] = `{{ ${key} }}`
+      }
+    }
+    setPreviewParams(paramsWithDefault)
+  }, [params, uin, uinType])
 
   return (
     <Flex
@@ -197,11 +213,7 @@ export const IssueSingleMemoPage = (): ReactElement => {
             <GridItem colSpan={{ base: 4, lg: 3 }} overflowY="scroll">
               <Box w="100%" maxW="48em" margin="0 auto" p="8" shadow="md">
                 <ReadonlyEditor
-                  value={render(template.body[0].data, {
-                    ...params,
-                    uin,
-                    uin_type: uinType,
-                  })}
+                  value={render(template.body[0].data, previewParams)}
                 />
               </Box>
             </GridItem>

--- a/frontend/src/pages/issue/IssueSingleMemoPage.tsx
+++ b/frontend/src/pages/issue/IssueSingleMemoPage.tsx
@@ -103,12 +103,15 @@ export const IssueSingleMemoPage = (): ReactElement => {
           </Box>
 
           {/* Body */}
-          <Grid templateColumns="repeat(4, 1fr)">
+          <Grid
+            templateColumns="repeat(4, 1fr)"
+            width="100%"
+            height="calc(100% - 77px)" // TODO fix this
+          >
             {/* Sidebar */}
             <GridItem
               borderRight="1px solid"
               borderColor="gray.200"
-              height="calc(100vh - 100px)"
               overflowY="scroll"
               colSpan={{ base: 4, lg: 1 }}
             >
@@ -191,7 +194,7 @@ export const IssueSingleMemoPage = (): ReactElement => {
             </GridItem>
 
             {/* Content */}
-            <GridItem colSpan={{ base: 4, lg: 3 }}>
+            <GridItem colSpan={{ base: 4, lg: 3 }} overflowY="scroll">
               <Box w="100%" maxW="48em" margin="0 auto" p="8" shadow="md">
                 <ReadonlyEditor
                   value={render(template.body[0].data, {


### PR DESCRIPTION
## Context

When issuing a single memo:
- Preview is cut off if the template is too long
- Parameters, which are blank by default, don't show up in the live preview

## Approach

- Allow scrolling in the live preview
- Set placeholders for unfilled parameters
