### PR TITLE
Fix/editor state bugs

### DIFF
--- a/backend/.env-example
+++ b/backend/.env-example
@@ -5,3 +5,4 @@ DB_HOST=localhost
 DB_USERNAME=""
 DB_PASSWORD=""
 DB_LOGGING=false
+AWS_REGION=

--- a/frontend/src/features/builder/EditorContext.tsx
+++ b/frontend/src/features/builder/EditorContext.tsx
@@ -71,6 +71,7 @@ export const useProvideEditor = (): EditorContextProps => {
   }, [value])
 
   const saveTemplate = useCallback(async () => {
+    setActiveEditorValue(JSON.stringify(value))
     const saveTemplateDto = {
       name: activeTemplateName,
       body: [
@@ -84,7 +85,7 @@ export const useProvideEditor = (): EditorContextProps => {
       return BuilderService.updateTemplate(activeEditorId, saveTemplateDto)
     }
     return BuilderService.saveTemplate(saveTemplateDto)
-  }, [activeTemplateName, activeEditorId, activeEditorValue])
+  }, [value, activeTemplateName, activeEditorValue, activeEditorId])
 
   return {
     status,

--- a/frontend/src/features/builder/EditorContext.tsx
+++ b/frontend/src/features/builder/EditorContext.tsx
@@ -45,7 +45,7 @@ export const useEditor = (): EditorContextProps => {
 
 export const useProvideEditor = (): EditorContextProps => {
   const { status, data: template } = useTemplate()
-  const [activeEditorId, setActiveEditorId] = useState<string>('defaultEditor')
+  const [activeEditorId, setActiveEditorId] = useState<string>('')
   const [initialEditorValue, setInitialEditorValue] = useState<string | null>(
     null,
   )

--- a/frontend/src/pages/builder/components/BuilderNavBarContainer.tsx
+++ b/frontend/src/pages/builder/components/BuilderNavBarContainer.tsx
@@ -10,7 +10,7 @@ import { BuilderNavBar } from './BuilderNavBar'
 
 const useBuilderNavBar = () => {
   const navigate = useNavigate()
-  const { activeTemplateName, saveTemplate } = useEditor()
+  const { activeTemplateName, resetEditor, saveTemplate } = useEditor()
   const toast = useToast()
 
   const handleBackToDashboard = useCallback(
@@ -37,6 +37,7 @@ const useBuilderNavBar = () => {
         status: 'error',
       })
     }
+    resetEditor()
     navigate(DASHBOARD_ROUTE)
   }
 

--- a/frontend/src/pages/builder/components/Editor.tsx
+++ b/frontend/src/pages/builder/components/Editor.tsx
@@ -147,7 +147,7 @@ export const Editor = ({
   const [readOnly] = useState<boolean>(editableProps?.readOnly || false)
   const plugins = getCommonPlugins()
   useEffect(() => {
-    setActiveEditorId(templateId || '')
+    setActiveEditorId(templateId || 'default')
     setWaitForTemplate(!!templateId && initialEditorValue === null)
   }, [initialEditorValue, setActiveEditorId, templateId])
 

--- a/frontend/src/pages/builder/components/Editor.tsx
+++ b/frontend/src/pages/builder/components/Editor.tsx
@@ -147,7 +147,7 @@ export const Editor = ({
   const [readOnly] = useState<boolean>(editableProps?.readOnly || false)
   const plugins = getCommonPlugins()
   useEffect(() => {
-    setActiveEditorId(templateId || 'defaultEditor')
+    setActiveEditorId(templateId || '')
     setWaitForTemplate(!!templateId && initialEditorValue === null)
   }, [initialEditorValue, setActiveEditorId, templateId])
 

--- a/frontend/src/pages/builder/components/Editor.tsx
+++ b/frontend/src/pages/builder/components/Editor.tsx
@@ -147,7 +147,7 @@ export const Editor = ({
   const [readOnly] = useState<boolean>(editableProps?.readOnly || false)
   const plugins = getCommonPlugins()
   useEffect(() => {
-    setActiveEditorId(templateId || '')
+    setActiveEditorId(templateId || 'defaultEditor')
     setWaitForTemplate(!!templateId && initialEditorValue === null)
   }, [initialEditorValue, setActiveEditorId, templateId])
 


### PR DESCRIPTION
## Context

**Bugs**
1. Switching between editing an existing template and creating a new template causes some weird state bugs with the editor.
2. Saving an edited template doesn't save the correct version sometimes.

## Approach

Rewired some of the states in `editor` and `editorContext`.
Bug (1) is caused by the typo in the slate editor ID for the default editor.
Bug (2) is caused by ???

## Edit
1. Stale state no longer appears in `Create new template`.
2. Stale state occurs when saving a new template. I have no idea how to fix this. The user has to exit and re-enter the template view once or twice, or they need to hard refresh.